### PR TITLE
Improve "datadir" handling

### DIFF
--- a/lib/dialable/area_codes.rb
+++ b/lib/dialable/area_codes.rb
@@ -3,11 +3,23 @@ require 'yaml'
 module Dialable
   module AreaCodes
 
-    # Valid area codes per nanpa.com
-    data_path = Gem.datadir('dialable')
-    data_path ||= File.join(File.dirname(__FILE__), '..', 'data', 'dialable')
+    def self.datadir
+      # If we are in the source directory, don't use the datadir from the gem.
+      datadir = if File.identical?(ENV['PWD'], File.join(File.dirname(__FILE__), '..', '..'))
+                  File.join(File.dirname(__FILE__), '..', '..', 'data', 'dialable')
+                else
+                  Gem.datadir('dialable')
+                end
 
-    NANP = YAML.load_file(File.join(data_path, 'nanpa.yaml'))
+      if ! File.directory?(datadir)
+        fail "Can't find the datadir provided by the gem: #{Gem.datadir('dialable')} or by the source: #{File.join(File.dirname(__FILE__), '..', 'data', 'dialable')}."
+      end
+
+      datadir
+    end
+
+    # Valid area codes per nanpa.com
+    NANP = YAML.load_file(File.join(datadir, 'nanpa.yaml'))
 
   end
 end

--- a/lib/dialable/version.rb
+++ b/lib/dialable/version.rb
@@ -1,3 +1,3 @@
 module Dialable
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
By default, during development or test, `dialable` would try to load the YAML data file from the gem, and not from the source directory. This fixes that!