### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/dialable/area_codes.rb
+++ b/lib/dialable/area_codes.rb
@@ -8,7 +8,7 @@ module Dialable
       datadir = if File.identical?(ENV['PWD'], File.join(File.dirname(__FILE__), '..', '..'))
                   File.join(File.dirname(__FILE__), '..', '..', 'data', 'dialable')
                 else
-                  Gem.datadir('dialable')
+                  Gem::Specification.find_by_name('dialable').datadir
                 end
 
       if ! File.directory?(datadir)


### PR DESCRIPTION
Addresses this warning:

>NOTE: Gem.datadir is deprecated; use spec.datadir instead. It will be removed on or after 2016-10-01.
>lib/dialable/area_codes.rb:11.

Results in `irb`, for illustration:

```ruby
$ irb
>> Gem.datadir('dialable')
NOTE: Gem.datadir is deprecated; use spec.datadir instead. It will be removed on or after 2016-10-01.
Gem.datadir called from (irb):1.
=> nil
>> Gem::Specification.find_by_name('dialable').datadir
=> ".../2.4.3/lib/ruby/gems/2.4.0/gems/dialable-1.0.2/data/dialable"
```